### PR TITLE
TLS client side certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 Gemfile.lock
 *~
 *.swp
+/result

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 cabal.sandbox.config
 node_modules
 Gemfile.lock
+*~
+*.swp

--- a/ldap-client.cabal
+++ b/ldap-client.cabal
@@ -25,6 +25,11 @@ source-repository head
   tag:      0.1.0
 
 library
+  ghc-options:
+    -Wall
+    -fwarn-incomplete-uni-patterns
+    -fwarn-incomplete-record-updates
+    -fwarn-unrecognised-pragmas
   default-language:
     Haskell2010
   hs-source-dirs:
@@ -56,6 +61,11 @@ library
     , text
 
 test-suite spec
+  ghc-options:
+    -Wall
+    -fwarn-incomplete-uni-patterns
+    -fwarn-incomplete-record-updates
+    -fwarn-unrecognised-pragmas
   default-language:
     Haskell2010
   type:

--- a/src/Ldap/Client.hs
+++ b/src/Ldap/Client.hs
@@ -162,6 +162,7 @@ with host port f = do
         case host of
           Plain    h -> h
           Secure   h -> h
+          SecureWithTLSSettings h _ -> h
           Insecure h -> h
     , Conn.connectionPort = port
     , Conn.connectionUseSecure =
@@ -172,6 +173,7 @@ with host port f = do
             , Conn.settingDisableSession = False
             , Conn.settingUseServerName = False
             }
+          SecureWithTLSSettings _ t -> Just t
           Insecure _ -> Just Conn.TLSSettingsSimple
             { Conn.settingDisableCertificateValidation = True
             , Conn.settingDisableSession = False

--- a/src/Ldap/Client/Internal.hs
+++ b/src/Ldap/Client/Internal.hs
@@ -36,6 +36,7 @@ import           Data.List.NonEmpty (NonEmpty)
 import           Data.Text (Text)
 import           Data.Typeable (Typeable)
 import           Network (PortNumber)
+import           Network.Connection (TLSSettings)
 
 import qualified Ldap.Asn1.Type as Type
 
@@ -46,7 +47,8 @@ data Host =
   | Insecure String -- ^ LDAP over TLS without the certificate validity check.
                     --   Only use for testing!
   | Secure String   -- ^ LDAP over TLS. Use!
-    deriving (Show, Eq, Ord)
+    | SecureWithTLSSettings String TLSSettings -- ^ LDAP over TLS with the ability to specify detailed TLS settings
+    deriving (Show)
 
 -- | A token. All functions that interact with the Directory require one.
 data Ldap = Ldap

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -41,12 +41,12 @@ locally :: (Ldap -> IO a) -> IO (Either LdapError a)
 locally f =
   bracket (do env <- getEnvironment
               (_, out, _, h) <- runInteractiveProcess "./test/ldap.js" [] Nothing
-                                  (Just (("PORT", show port) :
+                                  (Just (("PORT", show (port :: Int)) :
                                          ("SSL_CERT", "./ssl/cert.pem") :
                                          ("SSL_KEY", "./ssl/key.pem") :
                                          env))
-              hGetLine out
-              forkIO (() <$ tryIOError (forever (hGetLine out >>= putStrLn)))
+              _ <- hGetLine out
+              _ <- forkIO (() <$ tryIOError (forever (hGetLine out >>= putStrLn)))
               return h)
           (\h -> do terminateProcess h
                     waitForProcess h)


### PR DESCRIPTION
Implementation of https://github.com/supki/ldap-client/issues/5

Strictly speaking only the last commit is necessary and related to the issue though the other ones probably can't hurt, unless something adds -Werror and something changes the fact that it currently compiles without warnings.

One notable change is the removal of Eq and Ord from the Host data type, it is in an Internal module though and the instances seem unused in the package itself. TLSSettings does not seem to have instances for those because it contains functions.














































































































































































































































