### PR TITLE
SecureWithTLSSettings additions to the Haddock documentation

### DIFF
--- a/src/Ldap/Asn1/FromAsn1.hs
+++ b/src/Ldap/Asn1/FromAsn1.hs
@@ -19,8 +19,8 @@ import qualified Data.Text.Encoding as Text
 
 import           Ldap.Asn1.Type
 
-{-# ANN module "HLint: ignore Use const" #-}
-{-# ANN module "HLint: ignore Avoid lambda" #-}
+{-# ANN module ("HLint: ignore Use const" :: String) #-}
+{-# ANN module ("HLint: ignore Avoid lambda" :: String) #-}
 
 
 -- | Convert a part of ASN.1 stream to a LDAP type returning the remainder of the stream.

--- a/src/Ldap/Asn1/ToAsn1.hs
+++ b/src/Ldap/Asn1/ToAsn1.hs
@@ -15,6 +15,7 @@ import           Data.Foldable (fold, foldMap)
 import           Data.List.NonEmpty (NonEmpty)
 import           Data.Maybe (maybe)
 import           Data.Monoid (Endo(Endo), (<>), mempty)
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Prelude (Integer, (.), fromIntegral)
 
@@ -309,12 +310,22 @@ instance ToAsn1 ProtocolClientOp where
 @
 AuthenticationChoice ::= CHOICE {
      simple                  [0] OCTET STRING,
+     sasl                    [3] SaslCredentials,
      ...  }
+
+
+SaslCredentials ::= SEQUENCE {
+     mechanism               LDAPString,
+     credentials             OCTET STRING OPTIONAL }
 @
 -}
 instance ToAsn1 AuthenticationChoice where
   toAsn1 (Simple s) = other Asn1.Context 0 s
-
+  toAsn1 (Sasl External c) =
+    context 3 (fold
+      [ toAsn1 (LdapString (Text.pack "EXTERNAL"))
+      , maybe mempty (toAsn1 . LdapString) c
+      ])
 {- |
 @
 AttributeSelection ::= SEQUENCE OF selector LDAPString

--- a/src/Ldap/Asn1/Type.hs
+++ b/src/Ldap/Asn1/Type.hs
@@ -48,7 +48,14 @@ data ProtocolServerOp =
     deriving (Show, Eq)
 
 -- | Not really a choice until SASL is supported.
-newtype AuthenticationChoice = Simple ByteString
+data AuthenticationChoice =
+    Simple ByteString
+  | Sasl !SaslMechanism !(Maybe Text)
+    deriving (Show, Eq)
+
+-- | SASL Mechanism, for now only SASL EXTERNAL is supported
+data SaslMechanism =
+    External
     deriving (Show, Eq)
 
 -- | Scope of the search to be performed.

--- a/src/Ldap/Client.hs
+++ b/src/Ldap/Client.hs
@@ -109,7 +109,7 @@ import           Ldap.Client.Delete (delete)
 import           Ldap.Client.Compare (compare)
 import           Ldap.Client.Extended (Oid(..), extended)
 
-{-# ANN module "HLint: ignore Use first" #-}
+{-# ANN module ("HLint: ignore Use first" :: String) #-}
 
 
 newLdap :: IO Ldap

--- a/src/Ldap/Client.hs
+++ b/src/Ldap/Client.hs
@@ -18,6 +18,7 @@ module Ldap.Client
     -- * Bind
   , Password(..)
   , bind
+  , externalBind
     -- * Search
   , search
   , SearchEntry(..)
@@ -90,7 +91,7 @@ import           Ldap.Asn1.ToAsn1 (ToAsn1(toAsn1))
 import           Ldap.Asn1.FromAsn1 (FromAsn1, parseAsn1)
 import qualified Ldap.Asn1.Type as Type
 import           Ldap.Client.Internal
-import           Ldap.Client.Bind (Password(..), bind)
+import           Ldap.Client.Bind (Password(..), bind, externalBind)
 import           Ldap.Client.Search
   ( search
   , Search


### PR DESCRIPTION
I started using the recent additions from my other pull requests. Since it took me a while to figure out how to use them for this relatively common purpose (common to people who want to use this at all) I figured it might be helpful to have my connection test code as an example in the docs.

I put it into the docs for the Host type so it isn't so overwhelming for people who just get started with the library. If you know a better place I am open to changes.

It is mostly just a dump of my test code so I am sure it could be improved, though it should be relatively self-explanatory.

If you decide not to merge my other open merge request (SASL EXTERNAL auth) you should replace the last line of the example with one of the other bind operations. They work as they usually do.