### PR TITLE
Fix MonadFail-compile error with GHC 8.6

### DIFF
--- a/ldap-client.cabal
+++ b/ldap-client.cabal
@@ -17,6 +17,7 @@ tested-with:
   , GHC == 7.8.4
   , GHC == 7.10.1
   , GHC == 8.0.1
+  , GHC == 8.6.3
 extra-source-files:
   README.markdown
   CHANGELOG.markdown
@@ -57,6 +58,7 @@ library
     , bytestring
     , connection    >= 0.2
     , containers
+    , fail
     , network       >= 2.6
     , semigroups    >= 0.16
     , stm

--- a/src/Ldap/Asn1/FromAsn1.hs
+++ b/src/Ldap/Asn1/FromAsn1.hs
@@ -11,6 +11,7 @@ import           Control.Applicative (Alternative(..), liftA2, optional)
 import           Control.Applicative (Applicative(..), Alternative(..), liftA2, optional)
 #endif
 import           Control.Monad (MonadPlus(..), (>=>), guard)
+import qualified Control.Monad.Fail as Fail
 import           Data.ASN1.Types (ASN1)
 import qualified Data.ASN1.Types as Asn1
 import           Data.Foldable (asum)
@@ -409,6 +410,9 @@ instance Monad (Parser s) where
   return x = Parser (\s -> return (s, x))
   Parser mx >>= k =
     Parser (mx >=> \(s', x) -> unParser (k x) s')
+  fail = Fail.fail
+
+instance Fail.MonadFail (Parser s) where
   fail _ = empty
 
 instance MonadPlus (Parser s) where


### PR DESCRIPTION
Trying to compile with 8.6-version of GHC results in various errors of the form:
```
./ldap-client/src/Ldap/Asn1/FromAsn1.hs:59:5: error:
    • Could not deduce (Control.Monad.Fail.MonadFail (Parser [ASN1]))
        arising from a do statement
        with the failable pattern ‘Asn1.End Asn1.Sequence’
      from the context: FromAsn1 op
        bound by the instance declaration
        at src/Ldap/Asn1/FromAsn1.hs:54:10-50
    • In a stmt of a 'do' block: Asn1.End Asn1.Sequence <- next
      In the expression:
        do Asn1.Start Asn1.Sequence <- next
           i <- fromAsn1
           op <- fromAsn1
           Asn1.End Asn1.Sequence <- next
           ....
      In an equation for ‘fromAsn1’:
          fromAsn1
            = do Asn1.Start Asn1.Sequence <- next
                 i <- fromAsn1
                 op <- fromAsn1
                 ....
   |
59 |     Asn1.End Asn1.Sequence <- next
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[...]
```

This commit implements the following suggestions in order to fix them:
* https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6#MonadFailDesugaringbydefault
* https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail#Adaptingoldcode